### PR TITLE
issue8、9対応

### DIFF
--- a/packages/apps/kaimono_plus/lib/main.dart
+++ b/packages/apps/kaimono_plus/lib/main.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'pages/list_page_view_model.dart';
-import 'pages/sign_in_page.dart';
+import 'pages/kaimono_list_page/kaimono_list_page_view_model.dart';
+import 'pages/sign_in_page/sign_in_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,9 +16,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(
-          create: (_) => ListPageViewModel(),
-        ),
+        ChangeNotifierProvider(create: (_) => KaimonoListPageViewModel()),
       ],
       child: MaterialApp(
         title: 'Kaimono Plus',

--- a/packages/apps/kaimono_plus/lib/pages/ sign_up_page/sign_up_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/ sign_up_page/sign_up_page.dart
@@ -93,7 +93,7 @@ class SignUpPage extends StatelessWidget {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.amber,
                     foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    padding: const .symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/components/kaimono_list_item.part.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/components/kaimono_list_item.part.dart
@@ -1,9 +1,9 @@
-class ListItem {
+class KaimonoListItem {
   final String id;
   final String text;
   bool isCompleted;
 
-  ListItem({
+  KaimonoListItem({
     required this.id,
     required this.text,
     this.isCompleted = false,

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 import 'package:provider/provider.dart';
 
-import 'list_page_view_model.dart';
+import 'kaimono_list_page_view_model.dart';
 
-class ListPage extends StatelessWidget {
-  const ListPage({super.key});
+class KaimonoListPage extends StatelessWidget {
+  const KaimonoListPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<ListPageViewModel>(
+    return Consumer<KaimonoListPageViewModel>(
       builder: (context, vm, child) {
         return Scaffold(
           appBar: AppBar(
@@ -19,19 +19,13 @@ class ListPage extends StatelessWidget {
               onPressed: () {
                 _showDeleteAllDialog(context, vm);
               },
-              icon: const Icon(
-                Icons.delete_outline,
-                color: Colors.white,
-              ),
+              icon: const Icon(Icons.delete_outline, color: Colors.white),
             ),
             actions: [
               IconButton(
                 // FIXME: シェアボタンの実装
                 onPressed: () {},
-                icon: const Icon(
-                  Icons.ios_share,
-                  color: Colors.white,
-                ),
+                icon: const Icon(Icons.ios_share, color: Colors.white),
               ),
             ],
           ),
@@ -39,10 +33,7 @@ class ListPage extends StatelessWidget {
             onPressed: () => vm.addItem(),
             backgroundColor: Colors.amber,
             shape: const CircleBorder(),
-            child: const Icon(
-              Icons.add,
-              color: Colors.white,
-            ),
+            child: const Icon(Icons.add, color: Colors.white),
           ),
           body: Container(
             height: double.infinity,
@@ -50,14 +41,14 @@ class ListPage extends StatelessWidget {
             child: ListView.builder(
               controller: vm.scrollController,
               itemCount: vm.items.length,
-              padding: const EdgeInsets.all(16.0),
+              padding: const .all(16.0),
               itemBuilder: (context, index) {
                 final item = vm.items[index];
                 final isEditing = vm.editingItemId == item.id;
                 final controller = vm.getControllerForItem(item.id);
 
                 return Container(
-                  margin: const EdgeInsets.only(bottom: 8.0),
+                  margin: const .only(bottom: 8.0),
                   decoration: BoxDecoration(
                     color: Colors.white,
                     borderRadius: BorderRadius.circular(8),
@@ -71,14 +62,14 @@ class ListPage extends StatelessWidget {
                     child: Row(
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(left: 16.0),
+                          padding: const .only(left: 16.0),
                           child: InkWell(
                             onTap: () {
                               vm.toggleItem(item.id);
                             },
                             borderRadius: BorderRadius.circular(4),
                             child: Padding(
-                              padding: const EdgeInsets.all(4.0),
+                              padding: const .all(4.0),
                               child: item.isCompleted
                                   ? const Icon(
                                       Icons.check_box,
@@ -102,7 +93,7 @@ class ListPage extends StatelessWidget {
                         const Gap(8),
                         Expanded(
                           child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 16.0),
+                            padding: const .symmetric(vertical: 16.0),
                             child: isEditing && controller != null
                                 ? TextField(
                                     controller: controller,
@@ -113,7 +104,7 @@ class ListPage extends StatelessWidget {
                                       enabledBorder: InputBorder.none,
                                       focusedBorder: InputBorder.none,
                                       isDense: true,
-                                      contentPadding: EdgeInsets.zero,
+                                      contentPadding: .zero,
                                     ),
                                     style: const TextStyle(
                                       fontSize: 16,
@@ -121,8 +112,11 @@ class ListPage extends StatelessWidget {
                                     ),
                                     onChanged: (text) {
                                       // リアルタイムで保存
-                                      vm.updateItemText(item.id, text,
-                                          removeIfEmpty: false);
+                                      vm.updateItemText(
+                                        item.id,
+                                        text,
+                                        removeIfEmpty: false,
+                                      );
                                     },
                                     onSubmitted: (_) {
                                       vm.stopEditing(item.id);
@@ -169,10 +163,7 @@ class ListPage extends StatelessWidget {
     );
   }
 
-  void _showDeleteAllDialog(
-    BuildContext context,
-    ListPageViewModel vm,
-  ) {
+  void _showDeleteAllDialog(BuildContext context, KaimonoListPageViewModel vm) {
     if (vm.items.isEmpty) return;
     showDialog(
       context: context,
@@ -181,10 +172,7 @@ class ListPage extends StatelessWidget {
           title: const Center(
             child: Text(
               '全件削除',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
           ),
           content: const Text('すべてのアイテムを削除しますか？'),
@@ -201,9 +189,7 @@ class ListPage extends StatelessWidget {
                     vm.clearAllItems();
                     Navigator.of(dialogContext).pop();
                   },
-                  style: TextButton.styleFrom(
-                    foregroundColor: Colors.red,
-                  ),
+                  style: TextButton.styleFrom(foregroundColor: Colors.red),
                   child: const Text('削除'),
                 ),
               ],

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 
-import 'list_item.dart';
+import 'components/kaimono_list_item.part.dart';
 
-class ListPageViewModel extends ChangeNotifier {
-  final List<ListItem> _items = [];
+class KaimonoListPageViewModel extends ChangeNotifier {
+  final List<KaimonoListItem> _items = [];
   final ScrollController _scrollController = ScrollController();
   String? _editingItemId;
   final Map<String, TextEditingController> _itemControllers = {};
 
   ScrollController get scrollController => _scrollController;
-  List<ListItem> get items => List.unmodifiable(_items);
+  List<KaimonoListItem> get items => List.unmodifiable(_items);
   String? get editingItemId => _editingItemId;
 
   TextEditingController? getControllerForItem(String id) {
@@ -75,7 +75,7 @@ class ListPageViewModel extends ChangeNotifier {
 
     final index = _items.indexWhere((item) => item.id == id);
     if (index != -1) {
-      _items[index] = ListItem(
+      _items[index] = KaimonoListItem(
         id: _items[index].id,
         text: trimmedText,
         isCompleted: _items[index].isCompleted,
@@ -86,12 +86,7 @@ class ListPageViewModel extends ChangeNotifier {
 
   void addItem() {
     final newId = DateTime.now().millisecondsSinceEpoch.toString();
-    _items.add(
-      ListItem(
-        id: newId,
-        text: '',
-      ),
-    );
+    _items.add(KaimonoListItem(id: newId, text: ''));
     debugPrint('addItem: 新しいアイテムを追加します');
     notifyListeners();
 

--- a/packages/apps/kaimono_plus/lib/pages/list_page_provider.dart
+++ b/packages/apps/kaimono_plus/lib/pages/list_page_provider.dart
@@ -1,5 +1,0 @@
-import 'list_page_view_model.dart';
-
-// Provider設定用のエイリアス
-// main.dartで使用しやすくするため、ListPageViewModelをListPageProviderとして提供
-typedef ListPageProvider = ListPageViewModel;

--- a/packages/apps/kaimono_plus/lib/pages/password_reset_page/password_reset_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/password_reset_page/password_reset_page.dart
@@ -6,25 +6,20 @@ class PasswordResetPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.grey[100],
-      ),
+      appBar: AppBar(backgroundColor: Colors.grey[100]),
       body: Container(
         height: double.infinity,
         color: Colors.grey[100],
         child: SafeArea(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24.0),
+            padding: const .all(24.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 const SizedBox(height: 32),
                 const Text(
                   'パスワード再設定',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 48),
@@ -57,17 +52,14 @@ class PasswordResetPage extends StatelessWidget {
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.amber,
                     foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    padding: const .symmetric(vertical: 16),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(8),
                     ),
                   ),
                   child: const Text(
                     'パスワードをリセット',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                   ),
                 ),
               ],

--- a/packages/apps/kaimono_plus/lib/pages/sign_in_page/sign_in_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/sign_in_page/sign_in_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
-import 'list_page.dart';
-import 'password_reset_page.dart';
-import 'sign_up_page.dart';
+import '../ sign_up_page/sign_up_page.dart';
+import '../kaimono_list_page/kaimono_list_page.dart';
+import '../password_reset_page/password_reset_page.dart';
 
 class SignInPage extends StatelessWidget {
   const SignInPage({super.key});
@@ -74,7 +74,9 @@ class SignInPage extends StatelessWidget {
                   onPressed: () {
                     // FIXME: サインイン処理を実装
                     Navigator.of(context).push(
-                      MaterialPageRoute(builder: (context) => const ListPage()),
+                      MaterialPageRoute(
+                        builder: (context) => const KaimonoListPage(),
+                      ),
                     );
                   },
                   style: ElevatedButton.styleFrom(


### PR DESCRIPTION
closes #8 
closes #9 
## 概要
下記 4 点を対応しました🙌
- [x] Dart 3.10 以上で使えるドットショートハンドを使用する (e.g. Padding: const .all(24.0)) 
- [x] ListPage, ListItem の名前が曖昧なので買い物リストであれば KaimonoListPage, KaimonoItem のような名前にすると良さそう
- [x] typedef ListPageProvider = ListPageViewModel; の ListPageProvider は使われていないので削除で良さそう
- [x] pageごとにディレクトリを切って、関連ファイルをまとめる（pageとviewmodelなど）

こちらのPRで、[以前いただいていた指摘事項](https://github.com/a-utaya/kaimono-plus/pull/4)の対応完了の認識です！