### PR TITLE
買い物リストをいくつかタイルで保持＆表示できるようにする

### DIFF
--- a/packages/apps/kaimono_plus/firebase.json
+++ b/packages/apps/kaimono_plus/firebase.json
@@ -51,6 +51,9 @@
       "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run build"]
     }
   ],
+  "firestore": {
+    "rules": "firestore.rules"
+  },
   "hosting": {
     "public": "web",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],

--- a/packages/apps/kaimono_plus/firestore.rules
+++ b/packages/apps/kaimono_plus/firestore.rules
@@ -1,0 +1,10 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/shoppingLists/{listId} {
+      allow read, create, update, delete: if request.auth != null
+        && request.auth.uid == userId;
+    }
+  }
+}

--- a/packages/apps/kaimono_plus/lib/pages/home_shell_page/home_shell_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/home_shell_page/home_shell_page.dart
@@ -43,19 +43,29 @@ class _HomeShellPageState extends ConsumerState<HomeShellPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      extendBody: true,
-      body: IndexedStack(
-        index: _currentIndex,
+      body: Stack(
         children: [
-          ShoppingListHistoryPage(onOpenList: _openCreatedList),
-          const KaimonoListPage(showFloatingActionButton: false),
-          const MyPage(),
+          Positioned.fill(
+            child: IndexedStack(
+              index: _currentIndex,
+              children: [
+                ShoppingListHistoryPage(onOpenList: _openCreatedList),
+                const KaimonoListPage(showFloatingActionButton: false),
+                const MyPage(),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: _HomeBottomNavigationBar(
+              currentIndex: _currentIndex,
+              onSelectTab: _selectTab,
+              onCreateItem: _createShoppingListItem,
+            ),
+          ),
         ],
-      ),
-      bottomNavigationBar: _HomeBottomNavigationBar(
-        currentIndex: _currentIndex,
-        onSelectTab: _selectTab,
-        onCreateItem: _createShoppingListItem,
       ),
     );
   }
@@ -179,7 +189,7 @@ class _ShoppingListHistoryPageState
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const Text(
-                  '色を変える',
+                  'カードの色を変える',
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.w800,
@@ -192,7 +202,7 @@ class _ShoppingListHistoryPageState
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: _historyPaletteColors.length,
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 4,
+                    crossAxisCount: 3,
                     mainAxisSpacing: 12,
                     crossAxisSpacing: 12,
                   ),
@@ -300,7 +310,12 @@ class _ShoppingListHistoryPageState
           ];
 
     final historyGrid = GridView.builder(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+      padding: EdgeInsets.fromLTRB(
+        16,
+        16,
+        16,
+        MediaQuery.viewPaddingOf(context).bottom + 24,
+      ),
       itemCount: createdLists.length,
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
@@ -311,9 +326,8 @@ class _ShoppingListHistoryPageState
       itemBuilder: (context, index) {
         final list = createdLists[index];
         final isSelected = _selectedListIds.contains(list.id);
-        final isCurrentList = list.id == listState.currentListId;
-        final canReorder = _isReorderMode && !isCurrentList;
-        final cardColor = _cardColorFor(list, index);
+        final canReorder = _isReorderMode;
+        final cardColor = _cardColorFor(list);
 
         final card = _CreatedListCard(
           list: list,
@@ -330,15 +344,12 @@ class _ShoppingListHistoryPageState
             if (_isReorderMode) return;
             widget.onOpenList(list.id);
           },
-          onLongPress: () {
-            if (_isReorderMode) return;
-            _toggleSelection(list.id);
-          },
+          onLongPress: _isReorderMode ? null : () => _toggleSelection(list.id),
           onChangeColor: () => _showColorPicker(context, list),
           onDelete: () => _confirmDeleteList(context, ref, list),
         );
 
-        if (!_isReorderMode || isCurrentList) {
+        if (!_isReorderMode) {
           return card;
         }
 
@@ -355,20 +366,23 @@ class _ShoppingListHistoryPageState
               data: list.id,
               feedback: SizedBox(
                 width: 160,
-                height: 174,
-                child: Opacity(
-                  opacity: 0.92,
-                  child: _CreatedListCard(
-                    list: list,
-                    color: cardColor,
-                    isSelected: false,
-                    isSelectionMode: false,
-                    isReorderMode: true,
-                    canReorder: false,
-                    onTap: () {},
-                    onLongPress: () {},
-                    onChangeColor: () {},
-                    onDelete: () {},
+                height: 196,
+                child: Material(
+                  color: Colors.transparent,
+                  child: Opacity(
+                    opacity: 0.92,
+                    child: _CreatedListCard(
+                      list: list,
+                      color: cardColor,
+                      isSelected: false,
+                      isSelectionMode: false,
+                      isReorderMode: true,
+                      canReorder: false,
+                      onTap: () {},
+                      onLongPress: null,
+                      onChangeColor: () {},
+                      onDelete: () {},
+                    ),
                   ),
                 ),
               ),
@@ -394,8 +408,9 @@ class _ShoppingListHistoryPageState
       ),
       body: Container(
         width: double.infinity,
-        color: Colors.grey[100],
+        color: Colors.white,
         child: SafeArea(
+          bottom: false,
           child: createdLists.isEmpty
               ? const _HistoryEmptyState()
               : historyGrid,
@@ -404,31 +419,25 @@ class _ShoppingListHistoryPageState
     );
   }
 
-  Color _cardColorFor(CreatedKaimonoList list, int index) {
+  Color _cardColorFor(CreatedKaimonoList list) {
     final colorValue = list.colorValue;
     if (colorValue != null) {
       return Color(colorValue);
     }
-    return _historyCardColors[index % _historyCardColors.length];
+    return _defaultHistoryCardColor;
   }
 }
 
-const _historyCardColors = [
-  Color(0xFFFFF4C2),
-  Color(0xFFDFF7EA),
-  Color(0xFFFFE4EC),
-  Color(0xFFDDEEFF),
-];
+const _defaultHistoryCardColor = Color(0xFFFFF4C2);
 
+/// 履歴リストの背景色リスト
 const _historyPaletteColors = [
-  Color(0xFFFFF4C2),
+  _defaultHistoryCardColor,
   Color(0xFFDFF7EA),
   Color(0xFFFFE4EC),
   Color(0xFFDDEEFF),
   Color(0xFFFFE1C7),
   Color(0xFFE8DFFF),
-  Color(0xFFFFF9D9),
-  Color(0xFFE2F3F5),
 ];
 
 class _HistoryEmptyState extends StatelessWidget {
@@ -493,7 +502,7 @@ class _CreatedListCard extends StatelessWidget {
   final bool isReorderMode;
   final bool canReorder;
   final VoidCallback onTap;
-  final VoidCallback onLongPress;
+  final VoidCallback? onLongPress;
   final VoidCallback onChangeColor;
   final VoidCallback onDelete;
 
@@ -619,6 +628,7 @@ class _CreatedListCard extends StatelessWidget {
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
                     children: [
                       for (final item in previewItems)
                         Padding(
@@ -740,7 +750,7 @@ class _MyPageState extends ConsumerState<MyPage> {
       ),
       body: Container(
         width: double.infinity,
-        color: Colors.grey[100],
+        color: Colors.white,
         child: SafeArea(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(24, 24, 24, 120),
@@ -845,7 +855,7 @@ class _HomeBottomNavigationBar extends StatelessWidget {
             bottom: 12 + bottomPadding,
             child: Container(
               decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.7),
+                color: Colors.white.withValues(alpha: 0.85),
                 borderRadius: BorderRadius.circular(38),
               ),
               child: SizedBox(

--- a/packages/apps/kaimono_plus/lib/pages/home_shell_page/home_shell_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/home_shell_page/home_shell_page.dart
@@ -35,16 +35,21 @@ class _HomeShellPageState extends ConsumerState<HomeShellPage> {
     });
   }
 
+  void _openCreatedList(String id) {
+    ref.read(kaimonoListPageViewModelProvider.notifier).openCreatedList(id);
+    _selectTab(_listTabIndex);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       extendBody: true,
       body: IndexedStack(
         index: _currentIndex,
-        children: const [
-          ShoppingListHistoryPage(),
-          KaimonoListPage(showFloatingActionButton: false),
-          MyPage(),
+        children: [
+          ShoppingListHistoryPage(onOpenList: _openCreatedList),
+          const KaimonoListPage(showFloatingActionButton: false),
+          const MyPage(),
         ],
       ),
       bottomNavigationBar: _HomeBottomNavigationBar(
@@ -56,33 +61,616 @@ class _HomeShellPageState extends ConsumerState<HomeShellPage> {
   }
 }
 
-class ShoppingListHistoryPage extends StatelessWidget {
-  const ShoppingListHistoryPage({super.key});
+class ShoppingListHistoryPage extends ConsumerStatefulWidget {
+  const ShoppingListHistoryPage({
+    required this.onOpenList,
+    super.key,
+  });
+
+  final ValueChanged<String> onOpenList;
+
+  @override
+  ConsumerState<ShoppingListHistoryPage> createState() =>
+      _ShoppingListHistoryPageState();
+}
+
+class _ShoppingListHistoryPageState
+    extends ConsumerState<ShoppingListHistoryPage> {
+  final Set<String> _selectedListIds = {};
+  bool _isReorderMode = false;
+
+  bool get _isSelectionMode => _selectedListIds.isNotEmpty;
+
+  void _enterReorderMode() {
+    setState(() {
+      _selectedListIds.clear();
+      _isReorderMode = true;
+    });
+  }
+
+  void _exitReorderMode() {
+    setState(() {
+      _isReorderMode = false;
+    });
+  }
+
+  void _clearSelection() {
+    setState(_selectedListIds.clear);
+  }
+
+  void _toggleSelection(String id) {
+    setState(() {
+      if (!_selectedListIds.add(id)) {
+        _selectedListIds.remove(id);
+      }
+    });
+  }
+
+  void _syncSelectionWithLists(List<CreatedKaimonoList> createdLists) {
+    final validIds = createdLists.map((list) => list.id).toSet();
+    if (_selectedListIds.every(validIds.contains)) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {
+        _selectedListIds.removeWhere((id) => !validIds.contains(id));
+      });
+    });
+  }
+
+  void _confirmDeleteList(
+    BuildContext context,
+    WidgetRef ref,
+    CreatedKaimonoList list,
+  ) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => ConfirmDialog(
+        title: 'リストを削除',
+        content: '「${list.displayTitle}」を削除しますか？',
+        confirmText: '削除',
+        isDestructive: true,
+        onCancel: () => Navigator.of(dialogContext).pop(),
+        onConfirm: () {
+          ref
+              .read(kaimonoListPageViewModelProvider.notifier)
+              .deleteCreatedList(list.id);
+          Navigator.of(dialogContext).pop();
+        },
+      ),
+    );
+  }
+
+  void _confirmDeleteSelectedLists(BuildContext context) {
+    final selectedCount = _selectedListIds.length;
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => ConfirmDialog(
+        title: 'リストを削除',
+        content: '選択した$selectedCount件のリストを削除しますか？',
+        confirmText: '削除',
+        isDestructive: true,
+        onCancel: () => Navigator.of(dialogContext).pop(),
+        onConfirm: () {
+          ref
+              .read(kaimonoListPageViewModelProvider.notifier)
+              .deleteCreatedLists(_selectedListIds);
+          Navigator.of(dialogContext).pop();
+          _clearSelection();
+        },
+      ),
+    );
+  }
+
+  void _showColorPicker(BuildContext context, CreatedKaimonoList list) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return Dialog(
+          insetPadding: const EdgeInsets.all(16),
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '色を変える',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.black87,
+                  ),
+                ),
+                const Gap(16),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: _historyPaletteColors.length,
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 4,
+                    mainAxisSpacing: 12,
+                    crossAxisSpacing: 12,
+                  ),
+                  itemBuilder: (context, index) {
+                    final color = _historyPaletteColors[index];
+                    final isSelected = list.colorValue == color.toARGB32();
+                    return InkWell(
+                      onTap: () {
+                        ref
+                            .read(kaimonoListPageViewModelProvider.notifier)
+                            .updateCreatedListColor(list.id, color.toARGB32());
+                        Navigator.of(dialogContext).pop();
+                      },
+                      borderRadius: BorderRadius.circular(18),
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: color,
+                          borderRadius: BorderRadius.circular(18),
+                          border: Border.all(
+                            color: isSelected
+                                ? Colors.black87
+                                : Colors.black.withValues(alpha: 0.08),
+                            width: isSelected ? 2 : 1,
+                          ),
+                        ),
+                        child: isSelected
+                            ? const Icon(Icons.check, color: Colors.black87)
+                            : null,
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    final listState = ref.watch(kaimonoListPageViewModelProvider);
+    final createdLists = listState.createdLists;
+    _syncSelectionWithLists(createdLists);
+    final selectedCount = _selectedListIds.length;
+
+    final appBarTitle = _isSelectionMode
+        ? Text('$selectedCount件選択中')
+        : Text(_isReorderMode ? '並び替え' : '履歴');
+    final leading = _isSelectionMode
+        ? IconButton(
+            onPressed: _clearSelection,
+            icon: const Icon(Icons.close, color: Colors.white),
+          )
+        : _isReorderMode
+        ? IconButton(
+            onPressed: _exitReorderMode,
+            icon: const Icon(Icons.check, color: Colors.white),
+          )
+        : null;
+    final actions = _isSelectionMode
+        ? [
+            IconButton(
+              tooltip: '削除',
+              onPressed: () => _confirmDeleteSelectedLists(context),
+              icon: const Icon(Icons.delete_outline, color: Colors.white),
+            ),
+          ]
+        : _isReorderMode
+        ? [
+            TextButton(
+              onPressed: _exitReorderMode,
+              child: const Text(
+                '完了',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+          ]
+        : [
+            PopupMenuButton<String>(
+              icon: const Icon(Icons.more_horiz, color: Colors.white),
+              color: Colors.white,
+              onSelected: (value) {
+                if (value == 'reorder') {
+                  _enterReorderMode();
+                }
+              },
+              itemBuilder: (context) => const [
+                PopupMenuItem(
+                  value: 'reorder',
+                  child: Row(
+                    children: [
+                      Icon(Icons.swap_vert, size: 20),
+                      Gap(8),
+                      Text('並び替え'),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ];
+
+    final historyGrid = GridView.builder(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
+      itemCount: createdLists.length,
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        childAspectRatio: 0.92,
+      ),
+      itemBuilder: (context, index) {
+        final list = createdLists[index];
+        final isSelected = _selectedListIds.contains(list.id);
+        final isCurrentList = list.id == listState.currentListId;
+        final canReorder = _isReorderMode && !isCurrentList;
+        final cardColor = _cardColorFor(list, index);
+
+        final card = _CreatedListCard(
+          list: list,
+          color: cardColor,
+          isSelected: isSelected,
+          isSelectionMode: _isSelectionMode,
+          isReorderMode: _isReorderMode,
+          canReorder: canReorder,
+          onTap: () {
+            if (_isSelectionMode) {
+              _toggleSelection(list.id);
+              return;
+            }
+            if (_isReorderMode) return;
+            widget.onOpenList(list.id);
+          },
+          onLongPress: () {
+            if (_isReorderMode) return;
+            _toggleSelection(list.id);
+          },
+          onChangeColor: () => _showColorPicker(context, list),
+          onDelete: () => _confirmDeleteList(context, ref, list),
+        );
+
+        if (!_isReorderMode || isCurrentList) {
+          return card;
+        }
+
+        return DragTarget<String>(
+          onWillAcceptWithDetails: (details) => details.data != list.id,
+          onAcceptWithDetails: (details) {
+            ref
+                .read(kaimonoListPageViewModelProvider.notifier)
+                .moveCreatedList(details.data, list.id);
+          },
+          builder: (context, candidateData, rejectedData) {
+            final isHovering = candidateData.isNotEmpty;
+            return LongPressDraggable<String>(
+              data: list.id,
+              feedback: SizedBox(
+                width: 160,
+                height: 174,
+                child: Opacity(
+                  opacity: 0.92,
+                  child: _CreatedListCard(
+                    list: list,
+                    color: cardColor,
+                    isSelected: false,
+                    isSelectionMode: false,
+                    isReorderMode: true,
+                    canReorder: false,
+                    onTap: () {},
+                    onLongPress: () {},
+                    onChangeColor: () {},
+                    onDelete: () {},
+                  ),
+                ),
+              ),
+              childWhenDragging: Opacity(opacity: 0.35, child: card),
+              child: AnimatedScale(
+                scale: isHovering ? 0.96 : 1,
+                duration: const Duration(milliseconds: 120),
+                child: card,
+              ),
+            );
+          },
+        );
+      },
+    );
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.amber,
-        title: const Text('履歴'),
+        centerTitle: true,
+        leading: leading,
+        title: appBarTitle,
+        actions: actions,
       ),
       body: Container(
         width: double.infinity,
         color: Colors.grey[100],
-        child: const SafeArea(
-          child: Center(
-            child: Text(
+        child: SafeArea(
+          child: createdLists.isEmpty
+              ? const _HistoryEmptyState()
+              : historyGrid,
+        ),
+      ),
+    );
+  }
+
+  Color _cardColorFor(CreatedKaimonoList list, int index) {
+    final colorValue = list.colorValue;
+    if (colorValue != null) {
+      return Color(colorValue);
+    }
+    return _historyCardColors[index % _historyCardColors.length];
+  }
+}
+
+const _historyCardColors = [
+  Color(0xFFFFF4C2),
+  Color(0xFFDFF7EA),
+  Color(0xFFFFE4EC),
+  Color(0xFFDDEEFF),
+];
+
+const _historyPaletteColors = [
+  Color(0xFFFFF4C2),
+  Color(0xFFDFF7EA),
+  Color(0xFFFFE4EC),
+  Color(0xFFDDEEFF),
+  Color(0xFFFFE1C7),
+  Color(0xFFE8DFFF),
+  Color(0xFFFFF9D9),
+  Color(0xFFE2F3F5),
+];
+
+class _HistoryEmptyState extends StatelessWidget {
+  const _HistoryEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.receipt_long_outlined,
+              size: 44,
+              color: Colors.black38,
+            ),
+            Gap(12),
+            Text(
               'まだ履歴はありません',
               style: TextStyle(
                 fontSize: 16,
-                fontWeight: FontWeight.w600,
+                fontWeight: FontWeight.w700,
                 color: Colors.black54,
               ),
+            ),
+            Gap(6),
+            Text(
+              '買うものを追加すると、ここにリストが表示されます。',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                color: Colors.black45,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CreatedListCard extends StatelessWidget {
+  const _CreatedListCard({
+    required this.list,
+    required this.color,
+    required this.isSelected,
+    required this.isSelectionMode,
+    required this.isReorderMode,
+    required this.canReorder,
+    required this.onTap,
+    required this.onLongPress,
+    required this.onChangeColor,
+    required this.onDelete,
+  });
+
+  final CreatedKaimonoList list;
+  final Color color;
+  final bool isSelected;
+  final bool isSelectionMode;
+  final bool isReorderMode;
+  final bool canReorder;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+  final VoidCallback onChangeColor;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final previewItems = list.visibleItems.take(3).toList();
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        onLongPress: onLongPress,
+        borderRadius: BorderRadius.circular(18),
+        child: Ink(
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(
+              color: isSelected ? Colors.amber.shade800 : Colors.transparent,
+              width: 2,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.72),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Padding(
+                        padding: EdgeInsets.all(8),
+                        child: Icon(
+                          Icons.shopping_basket_outlined,
+                          size: 22,
+                          color: Colors.black87,
+                        ),
+                      ),
+                    ),
+                    const Spacer(),
+                    if (isSelectionMode)
+                      Icon(
+                        isSelected
+                            ? Icons.check_circle
+                            : Icons.radio_button_unchecked,
+                        color: isSelected
+                            ? Colors.amber.shade800
+                            : Colors.black38,
+                      )
+                    else if (isReorderMode)
+                      Icon(
+                        canReorder ? Icons.drag_handle : Icons.lock_outline,
+                        color: Colors.black45,
+                      )
+                    else
+                      SizedBox.square(
+                        dimension: 32,
+                        child: PopupMenuButton<String>(
+                          icon: const Icon(
+                            Icons.more_horiz,
+                            color: Colors.black54,
+                          ),
+                          color: Colors.white,
+                          padding: EdgeInsets.zero,
+                          onSelected: (value) {
+                            if (value == 'changeColor') {
+                              onChangeColor();
+                              return;
+                            }
+                            if (value == 'delete') {
+                              onDelete();
+                            }
+                          },
+                          itemBuilder: (context) => const [
+                            PopupMenuItem(
+                              value: 'changeColor',
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    Icons.palette_outlined,
+                                    size: 20,
+                                  ),
+                                  Gap(8),
+                                  Text('色を変える'),
+                                ],
+                              ),
+                            ),
+                            PopupMenuItem(
+                              value: 'delete',
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    Icons.delete_outline,
+                                    size: 20,
+                                    color: Colors.redAccent,
+                                  ),
+                                  Gap(8),
+                                  Text('削除'),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+                const Gap(12),
+                Text(
+                  list.displayTitle,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.black87,
+                  ),
+                ),
+                const Gap(10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final item in previewItems)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Row(
+                            children: [
+                              Icon(
+                                item.isCompleted
+                                    ? Icons.check_circle
+                                    : Icons.circle_outlined,
+                                size: 13,
+                                color: Colors.black45,
+                              ),
+                              const Gap(5),
+                              Expanded(
+                                child: Text(
+                                  item.text.trim(),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: Colors.black54,
+                                    fontSize: 12,
+                                    decoration: item.isCompleted
+                                        ? TextDecoration.lineThrough
+                                        : null,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                Text(
+                  _formatUpdatedAt(list.updatedAt),
+                  style: const TextStyle(
+                    color: Colors.black45,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
             ),
           ),
         ),
       ),
     );
+  }
+
+  String _formatUpdatedAt(DateTime updatedAt) {
+    return '${updatedAt.month}/${updatedAt.day} 更新';
   }
 }
 
@@ -147,6 +735,7 @@ class _MyPageState extends ConsumerState<MyPage> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.amber,
+        centerTitle: true,
         title: const Text('マイページ'),
       ),
       body: Container(
@@ -266,7 +855,7 @@ class _HomeBottomNavigationBar extends StatelessWidget {
                   children: [
                     Expanded(
                       child: _BottomNavigationItem(
-                        icon: Icons.history,
+                        icon: Icons.receipt_long_outlined,
                         label: '履歴',
                         isSelected: currentIndex == 0,
                         onTap: () => onSelectTab(0),

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/components/kaimono_list_item.part.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/components/kaimono_list_item.part.dart
@@ -68,8 +68,9 @@ class KaimonoListItem extends StatelessWidget {
                 child: isEditing
                     ? TextField(
                         controller: controller,
+                        focusNode: vm.getFocusNodeForItem(item.id),
                         cursorColor: Colors.amber,
-                        autofocus: true,
+                        textInputAction: TextInputAction.next,
                         decoration: const InputDecoration(
                           border: InputBorder.none,
                           enabledBorder: InputBorder.none,
@@ -87,11 +88,9 @@ class KaimonoListItem extends StatelessWidget {
                           );
                         },
                         onSubmitted: (_) {
-                          vm.stopEditing(item.id);
+                          vm.submitItem(item.id);
                         },
-                        onEditingComplete: () {
-                          vm.stopEditing(item.id);
-                        },
+                        onEditingComplete: () {},
                       )
                     : Text(
                         item.text,

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
@@ -118,10 +118,19 @@ class _KaimonoListPageState extends ConsumerState<KaimonoListPage> {
           IconButton(
             tooltip: '保存',
             onPressed: listState.visibleItems.isNotEmpty
-                ? () {
-                    final saved = notifier.saveCurrentList();
-                    if (!saved) return;
-                    showAppSnackBar(context, '買うものリストを保存しました');
+                ? () async {
+                    try {
+                      final saved = await notifier.saveCurrentList();
+                      if (!context.mounted || !saved) return;
+                      showAppSnackBar(context, '買うものリストを保存しました');
+                    } catch (_) {
+                      if (!context.mounted) return;
+                      showAppSnackBar(
+                        context,
+                        '買うものリストを保存できませんでした。Firestore の権限を確認してください。',
+                        isError: true,
+                      );
+                    }
                   }
                 : null,
             icon: const Icon(Icons.shopping_bag_outlined, color: Colors.white),
@@ -166,7 +175,7 @@ class _KaimonoListPageState extends ConsumerState<KaimonoListPage> {
           : null,
       body: Container(
         height: double.infinity,
-        color: Colors.grey[100],
+        color: Colors.white,
         child: Column(
           children: [
             Padding(

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page.dart
@@ -89,6 +89,7 @@ class _KaimonoListPageState extends ConsumerState<KaimonoListPage> {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.amber,
+        centerTitle: true,
         title: const Text('買い物リスト'),
         leading: IconButton(
           onPressed: () {
@@ -114,6 +115,17 @@ class _KaimonoListPageState extends ConsumerState<KaimonoListPage> {
           icon: const Icon(Icons.delete_outline, color: Colors.white),
         ),
         actions: [
+          IconButton(
+            tooltip: '保存',
+            onPressed: listState.visibleItems.isNotEmpty
+                ? () {
+                    final saved = notifier.saveCurrentList();
+                    if (!saved) return;
+                    showAppSnackBar(context, '買うものリストを保存しました');
+                  }
+                : null,
+            icon: const Icon(Icons.shopping_bag_outlined, color: Colors.white),
+          ),
           IconButton(
             onPressed: listState.hasShareableItems
                 ? () async {
@@ -155,23 +167,50 @@ class _KaimonoListPageState extends ConsumerState<KaimonoListPage> {
       body: Container(
         height: double.infinity,
         color: Colors.grey[100],
-        child: ReorderableListView.builder(
-          padding: EdgeInsets.fromLTRB(16, 16, 16, listBottomPadding),
-          itemCount: listState.items.length,
-          itemBuilder: (context, index) {
-            final item = listState.items[index];
-            final isEditing = listState.editingItemId == item.id;
-            final controller = notifier.getControllerForItem(item.id);
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: TextFormField(
+                key: ValueKey(listState.currentListId),
+                initialValue: listState.currentListTitle,
+                onChanged: notifier.updateListTitle,
+                maxLength: 30,
+                textInputAction: TextInputAction.done,
+                decoration: InputDecoration(
+                  counterText: '',
+                  filled: true,
+                  fillColor: Colors.white,
+                  hintText: 'リストのタイトル',
+                  prefixIcon: const Icon(Icons.shopping_bag_outlined),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: ReorderableListView.builder(
+                padding: EdgeInsets.fromLTRB(16, 16, 16, listBottomPadding),
+                itemCount: listState.items.length,
+                itemBuilder: (context, index) {
+                  final item = listState.items[index];
+                  final isEditing = listState.editingItemId == item.id;
+                  final controller = notifier.getControllerForItem(item.id);
 
-            return KaimonoListItem(
-              key: ValueKey(item.id),
-              item: item,
-              isEditing: isEditing,
-              controller: controller!,
-              notifier: notifier,
-            );
-          },
-          onReorder: notifier.reorderItems,
+                  return KaimonoListItem(
+                    key: ValueKey(item.id),
+                    item: item,
+                    isEditing: isEditing,
+                    controller: controller!,
+                    notifier: notifier,
+                  );
+                },
+                onReorder: notifier.reorderItems,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
@@ -46,20 +46,88 @@ class KaimonoItem {
 }
 
 @immutable
+class CreatedKaimonoList {
+  const CreatedKaimonoList({
+    required this.id,
+    required this.title,
+    required this.items,
+    required this.createdAt,
+    required this.updatedAt,
+    this.colorValue,
+  });
+
+  final String id;
+  final String title;
+  final List<KaimonoItem> items;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int? colorValue;
+
+  List<KaimonoItem> get visibleItems =>
+      items.where((item) => item.text.trim().isNotEmpty).toList();
+
+  String get displayTitle => title.trim().isEmpty ? '買うものリスト' : title;
+
+  int get completedCount =>
+      visibleItems.where((item) => item.isCompleted).length;
+
+  int get pendingCount => visibleItems.length - completedCount;
+
+  CreatedKaimonoList copyWith({
+    String? title,
+    List<KaimonoItem>? items,
+    DateTime? updatedAt,
+    int? colorValue,
+  }) {
+    return CreatedKaimonoList(
+      id: id,
+      title: title ?? this.title,
+      items: items ?? this.items,
+      createdAt: createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      colorValue: colorValue ?? this.colorValue,
+    );
+  }
+}
+
+@immutable
 class KaimonoListState {
   const KaimonoListState({
+    required this.currentListId,
+    required this.currentListTitle,
+    required this.currentListCreatedAt,
+    required this.currentListUpdatedAt,
     required this.items,
+    this.currentListColorValue,
+    this.historyLists = const [],
     this.editingItemId,
   });
 
+  final String currentListId;
+  final String currentListTitle;
+  final DateTime currentListCreatedAt;
+  final DateTime currentListUpdatedAt;
   final List<KaimonoItem> items;
+  final int? currentListColorValue;
+  final List<CreatedKaimonoList> historyLists;
   final String? editingItemId;
+
+  List<KaimonoItem> get visibleItems =>
+      items.where((item) => item.text.trim().isNotEmpty).toList();
 
   List<KaimonoItem> get shareableItems => items
       .where((item) => item.text.trim().isNotEmpty && !item.isCompleted)
       .toList();
 
   bool get hasShareableItems => shareableItems.isNotEmpty;
+
+  List<CreatedKaimonoList> get createdLists {
+    final currentList = _currentListSnapshot();
+    return [
+      if (currentList != null) currentList,
+      ...historyLists,
+    ];
+  }
 
   String get shareText {
     final lines = <String>['買うもの', ''];
@@ -70,14 +138,39 @@ class KaimonoListState {
   }
 
   KaimonoListState copyWith({
+    String? currentListId,
+    String? currentListTitle,
+    DateTime? currentListCreatedAt,
+    DateTime? currentListUpdatedAt,
     List<KaimonoItem>? items,
+    int? currentListColorValue,
+    List<CreatedKaimonoList>? historyLists,
     Object? editingItemId = _editingItemIdUnset,
   }) {
     return KaimonoListState(
+      currentListId: currentListId ?? this.currentListId,
+      currentListTitle: currentListTitle ?? this.currentListTitle,
+      currentListCreatedAt: currentListCreatedAt ?? this.currentListCreatedAt,
+      currentListUpdatedAt: currentListUpdatedAt ?? this.currentListUpdatedAt,
       items: items ?? this.items,
+      currentListColorValue:
+          currentListColorValue ?? this.currentListColorValue,
+      historyLists: historyLists ?? this.historyLists,
       editingItemId: identical(editingItemId, _editingItemIdUnset)
           ? this.editingItemId
           : editingItemId as String?,
+    );
+  }
+
+  CreatedKaimonoList? _currentListSnapshot() {
+    if (visibleItems.isEmpty) return null;
+    return CreatedKaimonoList(
+      id: currentListId,
+      title: currentListTitle,
+      items: items,
+      createdAt: currentListCreatedAt,
+      updatedAt: currentListUpdatedAt,
+      colorValue: currentListColorValue,
     );
   }
 }
@@ -103,7 +196,14 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       _itemControllers.clear();
       _scrollController.dispose();
     });
-    return const KaimonoListState(items: []);
+    final now = clock.now();
+    return KaimonoListState(
+      currentListId: _newListId(),
+      currentListTitle: '',
+      currentListCreatedAt: now,
+      currentListUpdatedAt: now,
+      items: const [],
+    );
   }
 
   TextEditingController? getControllerForItem(String id) {
@@ -165,16 +265,24 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
 
     final nextItems = [...state.items];
     nextItems[index] = nextItems[index].copyWith(text: trimmedText);
-    state = state.copyWith(items: nextItems);
+    state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
+  }
+
+  void updateListTitle(String title) {
+    state = state.copyWith(
+      currentListTitle: title.trim(),
+      currentListUpdatedAt: clock.now(),
+    );
   }
 
   void addItem() {
-    final newId = clock.now().millisecondsSinceEpoch.toString();
+    final newId = _newItemId();
     state = state.copyWith(
       items: [
         ...state.items,
         KaimonoItem(id: newId, text: ''),
       ],
+      currentListUpdatedAt: clock.now(),
     );
     debugPrint('addItem: 新しいアイテムを追加します');
 
@@ -197,7 +305,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final nextItems = [...state.items];
     final item = nextItems[index];
     nextItems[index] = item.copyWith(isCompleted: !item.isCompleted);
-    state = state.copyWith(items: nextItems);
+    state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
   }
 
   void removeItem(String id) {
@@ -206,7 +314,11 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     _itemControllers.remove(id);
 
     final nextEditing = state.editingItemId == id ? null : state.editingItemId;
-    state = state.copyWith(items: nextItems, editingItemId: nextEditing);
+    state = state.copyWith(
+      items: nextItems,
+      editingItemId: nextEditing,
+      currentListUpdatedAt: clock.now(),
+    );
   }
 
   void reorderItems(int oldIndex, int newIndex) {
@@ -216,7 +328,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final nextItems = [...state.items];
     final item = nextItems.removeAt(oldIndex);
     nextItems.insert(newIndex, item);
-    state = state.copyWith(items: nextItems);
+    state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
   }
 
   void clearAllItems() {
@@ -224,7 +336,127 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       controller.dispose();
     }
     _itemControllers.clear();
-    state = const KaimonoListState(items: []);
+    final now = clock.now();
+    state = KaimonoListState(
+      currentListId: _newListId(),
+      currentListTitle: '',
+      currentListCreatedAt: now,
+      currentListUpdatedAt: now,
+      items: const [],
+      historyLists: _historyWithCurrentSnapshot(),
+    );
+  }
+
+  bool saveCurrentList() {
+    if (state.visibleItems.isEmpty) return false;
+
+    for (final controller in _itemControllers.values) {
+      controller.dispose();
+    }
+    _itemControllers.clear();
+
+    final now = clock.now();
+    state = KaimonoListState(
+      currentListId: _newListId(),
+      currentListTitle: '',
+      currentListCreatedAt: now,
+      currentListUpdatedAt: now,
+      items: const [],
+      historyLists: _historyWithCurrentSnapshot(),
+    );
+    return true;
+  }
+
+  void openCreatedList(String id) {
+    if (id == state.currentListId) return;
+
+    final selectedList = state.historyLists
+        .where((list) => list.id == id)
+        .firstOrNull;
+    if (selectedList == null) return;
+
+    for (final controller in _itemControllers.values) {
+      controller.dispose();
+    }
+    _itemControllers.clear();
+
+    state = KaimonoListState(
+      currentListId: selectedList.id,
+      currentListTitle: selectedList.title,
+      currentListCreatedAt: selectedList.createdAt,
+      currentListUpdatedAt: clock.now(),
+      items: selectedList.items,
+      currentListColorValue: selectedList.colorValue,
+      historyLists: [
+        ..._historyWithCurrentSnapshot(),
+      ].where((list) => list.id != selectedList.id).toList(),
+    );
+  }
+
+  void deleteCreatedList(String id) {
+    deleteCreatedLists({id});
+  }
+
+  void deleteCreatedLists(Set<String> ids) {
+    final nextHistoryLists = state.historyLists
+        .where((list) => !ids.contains(list.id))
+        .toList();
+
+    if (!ids.contains(state.currentListId)) {
+      state = state.copyWith(historyLists: nextHistoryLists);
+      return;
+    }
+
+    for (final controller in _itemControllers.values) {
+      controller.dispose();
+    }
+    _itemControllers.clear();
+
+    final now = clock.now();
+    state = KaimonoListState(
+      currentListId: _newListId(),
+      currentListTitle: '',
+      currentListCreatedAt: now,
+      currentListUpdatedAt: now,
+      items: const [],
+      historyLists: nextHistoryLists,
+    );
+  }
+
+  void moveCreatedList(String movedId, String targetId) {
+    if (movedId == targetId) return;
+    if (movedId == state.currentListId || targetId == state.currentListId) {
+      return;
+    }
+
+    final nextHistoryLists = [...state.historyLists];
+    final oldIndex = nextHistoryLists.indexWhere((list) => list.id == movedId);
+    final newIndex = nextHistoryLists.indexWhere((list) => list.id == targetId);
+    if (oldIndex == -1 || newIndex == -1) return;
+
+    final movedList = nextHistoryLists.removeAt(oldIndex);
+    nextHistoryLists.insert(newIndex, movedList);
+    state = state.copyWith(historyLists: nextHistoryLists);
+  }
+
+  void updateCreatedListColor(String id, int colorValue) {
+    if (id == state.currentListId) {
+      state = state.copyWith(
+        currentListColorValue: colorValue,
+        currentListUpdatedAt: clock.now(),
+      );
+      return;
+    }
+
+    state = state.copyWith(
+      historyLists: [
+        for (final list in state.historyLists)
+          if (list.id == id)
+            list.copyWith(colorValue: colorValue, updatedAt: clock.now())
+          else
+            list,
+      ],
+    );
   }
 
   Future<SharedKaimonoList> createSharedList() async {
@@ -288,6 +520,28 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       controller.dispose();
     }
     _itemControllers.clear();
-    state = KaimonoListState(items: nextItems);
+    final now = clock.now();
+    state = KaimonoListState(
+      currentListId: _newListId(),
+      currentListTitle: '',
+      currentListCreatedAt: now,
+      currentListUpdatedAt: now,
+      items: nextItems,
+      historyLists: _historyWithCurrentSnapshot(),
+    );
   }
+
+  List<CreatedKaimonoList> _historyWithCurrentSnapshot() {
+    final currentList = state._currentListSnapshot();
+    if (currentList == null) return state.historyLists;
+
+    return [
+      currentList,
+      ...state.historyLists.where((list) => list.id != currentList.id),
+    ];
+  }
+
+  String _newListId() => 'list-${clock.now().microsecondsSinceEpoch}';
+
+  String _newItemId() => 'item-${clock.now().microsecondsSinceEpoch}';
 }

--- a/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
+++ b/packages/apps/kaimono_plus/lib/pages/kaimono_list_page/kaimono_list_page_view_model.dart
@@ -1,7 +1,12 @@
-import 'package:cloud_functions/cloud_functions.dart';
+import 'dart:async';
+
 import 'package:clock/clock.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/authenticator_provider.dart';
 
 /// [KaimonoListState.copyWith] で `editingItemId` を変更しない場合と、
 /// 明示的に `null` へ更新する場合を区別するための sentinel。
@@ -97,6 +102,7 @@ class KaimonoListState {
     required this.currentListTitle,
     required this.currentListCreatedAt,
     required this.currentListUpdatedAt,
+    required this.currentListIsSaved,
     required this.items,
     this.currentListColorValue,
     this.historyLists = const [],
@@ -107,6 +113,7 @@ class KaimonoListState {
   final String currentListTitle;
   final DateTime currentListCreatedAt;
   final DateTime currentListUpdatedAt;
+  final bool currentListIsSaved;
   final List<KaimonoItem> items;
   final int? currentListColorValue;
   final List<CreatedKaimonoList> historyLists;
@@ -122,10 +129,25 @@ class KaimonoListState {
   bool get hasShareableItems => shareableItems.isNotEmpty;
 
   List<CreatedKaimonoList> get createdLists {
-    final currentList = _currentListSnapshot();
+    final currentList = currentListIsSaved ? _currentListSnapshot() : null;
+    if (currentList == null) {
+      return historyLists;
+    }
+
+    var didReplaceCurrentList = false;
+    final lists = <CreatedKaimonoList>[];
+    for (final list in historyLists) {
+      if (list.id == currentList.id) {
+        lists.add(currentList);
+        didReplaceCurrentList = true;
+      } else {
+        lists.add(list);
+      }
+    }
+
     return [
-      if (currentList != null) currentList,
-      ...historyLists,
+      if (!didReplaceCurrentList) currentList,
+      ...lists,
     ];
   }
 
@@ -142,6 +164,7 @@ class KaimonoListState {
     String? currentListTitle,
     DateTime? currentListCreatedAt,
     DateTime? currentListUpdatedAt,
+    bool? currentListIsSaved,
     List<KaimonoItem>? items,
     int? currentListColorValue,
     List<CreatedKaimonoList>? historyLists,
@@ -152,6 +175,7 @@ class KaimonoListState {
       currentListTitle: currentListTitle ?? this.currentListTitle,
       currentListCreatedAt: currentListCreatedAt ?? this.currentListCreatedAt,
       currentListUpdatedAt: currentListUpdatedAt ?? this.currentListUpdatedAt,
+      currentListIsSaved: currentListIsSaved ?? this.currentListIsSaved,
       items: items ?? this.items,
       currentListColorValue:
           currentListColorValue ?? this.currentListColorValue,
@@ -163,15 +187,123 @@ class KaimonoListState {
   }
 
   CreatedKaimonoList? _currentListSnapshot() {
-    if (visibleItems.isEmpty) return null;
+    final savedItems = visibleItems;
+    if (savedItems.isEmpty) return null;
     return CreatedKaimonoList(
       id: currentListId,
       title: currentListTitle,
-      items: items,
+      items: savedItems,
       createdAt: currentListCreatedAt,
       updatedAt: currentListUpdatedAt,
       colorValue: currentListColorValue,
     );
+  }
+}
+
+class _ShoppingListRepository {
+  _ShoppingListRepository({
+    FirebaseFirestore? firestore,
+  }) : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _shoppingListsRef(String uid) {
+    return _firestore.collection('users').doc(uid).collection('shoppingLists');
+  }
+
+  Stream<List<CreatedKaimonoList>> watchShoppingLists(String uid) {
+    return _shoppingListsRef(uid)
+        .orderBy('sortOrder')
+        .snapshots()
+        .map(
+          (snapshot) => [
+            for (final doc in snapshot.docs) _listFromDoc(doc),
+          ],
+        );
+  }
+
+  Future<void> saveShoppingLists({
+    required String uid,
+    required List<CreatedKaimonoList> lists,
+  }) async {
+    final batch = _firestore.batch();
+    final collection = _shoppingListsRef(uid);
+    for (final (index, list) in lists.indexed) {
+      batch.set(
+        collection.doc(list.id),
+        _listToData(list, sortOrder: index),
+        SetOptions(merge: true),
+      );
+    }
+    await batch.commit();
+  }
+
+  Future<void> deleteShoppingLists({
+    required String uid,
+    required Iterable<String> ids,
+  }) async {
+    final batch = _firestore.batch();
+    final collection = _shoppingListsRef(uid);
+    for (final id in ids) {
+      batch.delete(collection.doc(id));
+    }
+    await batch.commit();
+  }
+
+  CreatedKaimonoList _listFromDoc(
+    QueryDocumentSnapshot<Map<String, dynamic>> doc,
+  ) {
+    final data = doc.data();
+    final rawItems = data['items'];
+    return CreatedKaimonoList(
+      id: doc.id,
+      title: (data['title'] as String?) ?? '',
+      items: [
+        if (rawItems is List)
+          for (final rawItem in rawItems)
+            if (rawItem is Map)
+              KaimonoItem(
+                id: (rawItem['id'] as String?) ?? _fallbackItemId(doc.id),
+                text: (rawItem['text'] as String?) ?? '',
+                isCompleted: (rawItem['isCompleted'] as bool?) ?? false,
+              ),
+      ],
+      createdAt: _dateFromData(data['createdAt']),
+      updatedAt: _dateFromData(data['updatedAt']),
+      colorValue: data['colorValue'] as int?,
+    );
+  }
+
+  Map<String, dynamic> _listToData(
+    CreatedKaimonoList list, {
+    required int sortOrder,
+  }) {
+    return {
+      'title': list.title,
+      'items': [
+        for (final item in list.items)
+          {
+            'id': item.id,
+            'text': item.text,
+            'isCompleted': item.isCompleted,
+          },
+      ],
+      'createdAt': Timestamp.fromDate(list.createdAt),
+      'updatedAt': Timestamp.fromDate(list.updatedAt),
+      'colorValue': list.colorValue,
+      'sortOrder': sortOrder,
+    };
+  }
+
+  DateTime _dateFromData(Object? value) {
+    if (value is Timestamp) {
+      return value.toDate();
+    }
+    return clock.now();
+  }
+
+  String _fallbackItemId(String listId) {
+    return '$listId-item-${clock.now().microsecondsSinceEpoch}';
   }
 }
 
@@ -183,25 +315,41 @@ final kaimonoListPageViewModelProvider =
 class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
   final ScrollController _scrollController = ScrollController();
   final Map<String, TextEditingController> _itemControllers = {};
+  final Map<String, FocusNode> _itemFocusNodes = {};
   final FirebaseFunctions _functions = FirebaseFunctions.instance;
+  final _shoppingListRepository = _ShoppingListRepository();
+  StreamSubscription<List<CreatedKaimonoList>>? _shoppingListsSubscription;
+  String? _uid;
 
   ScrollController get scrollController => _scrollController;
 
   @override
   KaimonoListState build() {
     ref.onDispose(() {
-      for (final controller in _itemControllers.values) {
-        controller.dispose();
-      }
-      _itemControllers.clear();
+      _shoppingListsSubscription?.cancel();
+      _disposeItemInputs();
       _scrollController.dispose();
     });
+    ref.listen(authStateChangesProvider, (_, authState) {
+      final user = authState.value;
+      if (user == null) {
+        _setUid(null);
+        return;
+      }
+      _setUid(user.uid);
+    });
     final now = clock.now();
+    Future<void>.microtask(() {
+      if (!ref.mounted) return;
+      final user = ref.read(authStateChangesProvider).value;
+      _setUid(user?.uid);
+    });
     return KaimonoListState(
       currentListId: _newListId(),
       currentListTitle: '',
       currentListCreatedAt: now,
       currentListUpdatedAt: now,
+      currentListIsSaved: false,
       items: const [],
     );
   }
@@ -220,6 +368,10 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     return _itemControllers[id];
   }
 
+  FocusNode getFocusNodeForItem(String id) {
+    return _itemFocusNodes.putIfAbsent(id, FocusNode.new);
+  }
+
   void startEditing(String id, {bool isNewItem = false}) {
     final currentEditing = state.editingItemId;
     if (currentEditing != null && currentEditing != id) {
@@ -233,12 +385,37 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
           TextPosition(offset: controller.text.length),
         );
       }
+      _itemFocusNodes[id]?.requestFocus();
     });
   }
 
   void stopEditing(String id, {bool skipIfEmpty = false}) {
     state = state.copyWith(editingItemId: null);
     _saveItemText(id, skipIfEmpty: skipIfEmpty);
+  }
+
+  void submitItem(String id) {
+    final controller = _itemControllers[id];
+    final text = controller?.text.trim() ?? '';
+    if (text.isEmpty) {
+      removeItem(id);
+      return;
+    }
+
+    updateItemText(id, text);
+    final currentIndex = state.items.indexWhere((item) => item.id == id);
+    if (currentIndex == -1) return;
+
+    final nextEmptyItem = state.items
+        .skip(currentIndex + 1)
+        .where((item) => item.text.trim().isEmpty)
+        .firstOrNull;
+    if (nextEmptyItem != null) {
+      startEditing(nextEmptyItem.id);
+      return;
+    }
+
+    addItem();
   }
 
   void _saveItemText(String id, {bool skipIfEmpty = false}) {
@@ -266,6 +443,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final nextItems = [...state.items];
     nextItems[index] = nextItems[index].copyWith(text: trimmedText);
     state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
+    _savePersistedLists();
   }
 
   void updateListTitle(String title) {
@@ -273,6 +451,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       currentListTitle: title.trim(),
       currentListUpdatedAt: clock.now(),
     );
+    _savePersistedLists();
   }
 
   void addItem() {
@@ -284,6 +463,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       ],
       currentListUpdatedAt: clock.now(),
     );
+    _savePersistedLists();
     debugPrint('addItem: 新しいアイテムを追加します');
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -306,12 +486,15 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final item = nextItems[index];
     nextItems[index] = item.copyWith(isCompleted: !item.isCompleted);
     state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
+    _savePersistedLists();
   }
 
   void removeItem(String id) {
     final nextItems = state.items.where((item) => item.id != id).toList();
     _itemControllers[id]?.dispose();
     _itemControllers.remove(id);
+    _itemFocusNodes[id]?.dispose();
+    _itemFocusNodes.remove(id);
 
     final nextEditing = state.editingItemId == id ? null : state.editingItemId;
     state = state.copyWith(
@@ -319,6 +502,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       editingItemId: nextEditing,
       currentListUpdatedAt: clock.now(),
     );
+    _savePersistedLists();
   }
 
   void reorderItems(int oldIndex, int newIndex) {
@@ -329,31 +513,43 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final item = nextItems.removeAt(oldIndex);
     nextItems.insert(newIndex, item);
     state = state.copyWith(items: nextItems, currentListUpdatedAt: clock.now());
+    _savePersistedLists();
   }
 
   void clearAllItems() {
-    for (final controller in _itemControllers.values) {
-      controller.dispose();
-    }
-    _itemControllers.clear();
+    _disposeItemInputs();
     final now = clock.now();
     state = KaimonoListState(
       currentListId: _newListId(),
       currentListTitle: '',
       currentListCreatedAt: now,
       currentListUpdatedAt: now,
+      currentListIsSaved: false,
       items: const [],
-      historyLists: _historyWithCurrentSnapshot(),
+      historyLists: _historyListsWithCurrentSavedSnapshot(),
     );
+    _savePersistedLists();
   }
 
-  bool saveCurrentList() {
-    if (state.visibleItems.isEmpty) return false;
+  Future<bool> saveCurrentList() async {
+    final currentList = state._currentListSnapshot();
+    if (currentList == null) return false;
 
-    for (final controller in _itemControllers.values) {
-      controller.dispose();
+    final uid = _currentUid();
+    if (uid == null) {
+      throw StateError('ログイン状態を確認できませんでした');
     }
-    _itemControllers.clear();
+
+    final nextHistoryLists = [
+      currentList,
+      ...state.historyLists.where((list) => list.id != currentList.id),
+    ];
+    await _shoppingListRepository.saveShoppingLists(
+      uid: uid,
+      lists: nextHistoryLists,
+    );
+
+    _disposeItemInputs();
 
     final now = clock.now();
     state = KaimonoListState(
@@ -361,8 +557,9 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       currentListTitle: '',
       currentListCreatedAt: now,
       currentListUpdatedAt: now,
+      currentListIsSaved: false,
       items: const [],
-      historyLists: _historyWithCurrentSnapshot(),
+      historyLists: nextHistoryLists,
     );
     return true;
   }
@@ -370,26 +567,22 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
   void openCreatedList(String id) {
     if (id == state.currentListId) return;
 
-    final selectedList = state.historyLists
+    final selectedList = state.createdLists
         .where((list) => list.id == id)
         .firstOrNull;
     if (selectedList == null) return;
 
-    for (final controller in _itemControllers.values) {
-      controller.dispose();
-    }
-    _itemControllers.clear();
+    _disposeItemInputs();
 
     state = KaimonoListState(
       currentListId: selectedList.id,
       currentListTitle: selectedList.title,
       currentListCreatedAt: selectedList.createdAt,
       currentListUpdatedAt: clock.now(),
+      currentListIsSaved: true,
       items: selectedList.items,
       currentListColorValue: selectedList.colorValue,
-      historyLists: [
-        ..._historyWithCurrentSnapshot(),
-      ].where((list) => list.id != selectedList.id).toList(),
+      historyLists: _historyListsWithCurrentSavedSnapshot(),
     );
   }
 
@@ -404,13 +597,11 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
 
     if (!ids.contains(state.currentListId)) {
       state = state.copyWith(historyLists: nextHistoryLists);
+      _deletePersistedLists(ids);
       return;
     }
 
-    for (final controller in _itemControllers.values) {
-      controller.dispose();
-    }
-    _itemControllers.clear();
+    _disposeItemInputs();
 
     final now = clock.now();
     state = KaimonoListState(
@@ -418,18 +609,17 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       currentListTitle: '',
       currentListCreatedAt: now,
       currentListUpdatedAt: now,
+      currentListIsSaved: false,
       items: const [],
       historyLists: nextHistoryLists,
     );
+    _deletePersistedLists(ids);
   }
 
   void moveCreatedList(String movedId, String targetId) {
     if (movedId == targetId) return;
-    if (movedId == state.currentListId || targetId == state.currentListId) {
-      return;
-    }
 
-    final nextHistoryLists = [...state.historyLists];
+    final nextHistoryLists = _historyListsWithCurrentSavedSnapshot();
     final oldIndex = nextHistoryLists.indexWhere((list) => list.id == movedId);
     final newIndex = nextHistoryLists.indexWhere((list) => list.id == targetId);
     if (oldIndex == -1 || newIndex == -1) return;
@@ -437,6 +627,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
     final movedList = nextHistoryLists.removeAt(oldIndex);
     nextHistoryLists.insert(newIndex, movedList);
     state = state.copyWith(historyLists: nextHistoryLists);
+    _savePersistedLists();
   }
 
   void updateCreatedListColor(String id, int colorValue) {
@@ -445,6 +636,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
         currentListColorValue: colorValue,
         currentListUpdatedAt: clock.now(),
       );
+      _savePersistedLists();
       return;
     }
 
@@ -457,6 +649,7 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
             list,
       ],
     );
+    _savePersistedLists();
   }
 
   Future<SharedKaimonoList> createSharedList() async {
@@ -516,32 +709,107 @@ class KaimonoListPageNotifier extends Notifier<KaimonoListState> {
       throw StateError('共有リストを開けませんでした');
     }
 
-    for (final controller in _itemControllers.values) {
-      controller.dispose();
-    }
-    _itemControllers.clear();
+    _disposeItemInputs();
     final now = clock.now();
     state = KaimonoListState(
       currentListId: _newListId(),
       currentListTitle: '',
       currentListCreatedAt: now,
       currentListUpdatedAt: now,
+      currentListIsSaved: false,
       items: nextItems,
-      historyLists: _historyWithCurrentSnapshot(),
+      historyLists: _historyListsWithCurrentSavedSnapshot(),
     );
+    _savePersistedLists();
   }
 
-  List<CreatedKaimonoList> _historyWithCurrentSnapshot() {
+  List<CreatedKaimonoList> _historyListsWithCurrentSavedSnapshot() {
+    if (!state.currentListIsSaved) return state.historyLists;
+
     final currentList = state._currentListSnapshot();
     if (currentList == null) return state.historyLists;
 
+    var didReplaceCurrentList = false;
+    final lists = <CreatedKaimonoList>[];
+    for (final list in state.historyLists) {
+      if (list.id == currentList.id) {
+        lists.add(currentList);
+        didReplaceCurrentList = true;
+      } else {
+        lists.add(list);
+      }
+    }
     return [
-      currentList,
-      ...state.historyLists.where((list) => list.id != currentList.id),
+      if (!didReplaceCurrentList) currentList,
+      ...lists,
     ];
   }
 
   String _newListId() => 'list-${clock.now().microsecondsSinceEpoch}';
 
   String _newItemId() => 'item-${clock.now().microsecondsSinceEpoch}';
+
+  void _disposeItemInputs() {
+    for (final controller in _itemControllers.values) {
+      controller.dispose();
+    }
+    for (final focusNode in _itemFocusNodes.values) {
+      focusNode.dispose();
+    }
+    _itemControllers.clear();
+    _itemFocusNodes.clear();
+  }
+
+  void _setUid(String? uid) {
+    if (_uid == uid) return;
+    _uid = uid;
+    unawaited(_shoppingListsSubscription?.cancel());
+    _shoppingListsSubscription = null;
+
+    if (uid == null) return;
+
+    _shoppingListsSubscription = _shoppingListRepository
+        .watchShoppingLists(uid)
+        .listen(
+          (lists) {
+            if (!ref.mounted) return;
+            state = state.copyWith(historyLists: lists);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            debugPrint('買い物リスト履歴の取得に失敗しました: $error');
+          },
+        );
+  }
+
+  List<CreatedKaimonoList> _persistedLists() {
+    return _historyListsWithCurrentSavedSnapshot();
+  }
+
+  String? _currentUid() {
+    return _uid ?? ref.read(authStateChangesProvider).value?.uid;
+  }
+
+  void _savePersistedLists() {
+    final uid = _currentUid();
+    if (uid == null) return;
+    unawaited(
+      _shoppingListRepository
+          .saveShoppingLists(uid: uid, lists: _persistedLists())
+          .catchError((Object error, StackTrace stackTrace) {
+            debugPrint('買い物リスト履歴の保存に失敗しました: $error');
+          }),
+    );
+  }
+
+  void _deletePersistedLists(Set<String> ids) {
+    final uid = _uid;
+    if (uid == null || ids.isEmpty) return;
+    unawaited(
+      _shoppingListRepository
+          .deleteShoppingLists(uid: uid, ids: ids)
+          .catchError((Object error, StackTrace stackTrace) {
+            debugPrint('買い物リスト履歴の削除に失敗しました: $error');
+          }),
+    );
+  }
 }

--- a/packages/apps/kaimono_plus/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/apps/kaimono_plus/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import cloud_firestore
 import cloud_functions
 import firebase_auth
 import firebase_core
@@ -13,6 +14,7 @@ import share_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FirebaseFunctionsPlugin.register(with: registry.registrar(forPlugin: "FirebaseFunctionsPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))

--- a/packages/apps/kaimono_plus/pubspec.yaml
+++ b/packages/apps/kaimono_plus/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   app_links: ^7.0.0
   auth:
     path: ../../core/auth
+  cloud_firestore: ^6.1.2
   cloud_functions: 6.0.6
   design_system:
     path: ../../design_system

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  cloud_firestore:
+    dependency: transitive
+    description:
+      name: cloud_firestore
+      sha256: "3ac242332166ae5037bd87bc343744bb96d88d7b13f791492b00958ce5cc6c63"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      sha256: "1bd08b736e1015e8bf5448f5ef67b2087a2380c2c1c7972f8403c1c7b41f5359"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      sha256: "18617275ffa2331d3ea058c515ef218bcce2ae13a14bee922563ca6ae2507c26"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
   cloud_functions:
     dependency: transitive
     description:


### PR DESCRIPTION
closes #18 
## 概要

- 履歴画面を作成し、作成済みの買い物リストを保持できるようにする
- 並び替え、削除機能を持たせる
- 背景色も変えられるようにする

## 動作エビデンス